### PR TITLE
Make fast-louvain importable directly from the git repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ path = "modules/bin/louvain.rs"
 members = ["modules/cli", "modules/application", "modules/domain"]
 
 [dependencies]
-# Workspace dependencies
-louvain-cli = "0.0.0"
+louvain-cli = { path = "modules/cli" }
 
 [patch.crates-io]
 louvain-cli = { path = "modules/cli" }

--- a/modules/application/Cargo.toml
+++ b/modules/application/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 # Workspace dependencies
-louvain-domain = "0.0.0"
+louvain-domain = { path = "../domain" }
 
 # External dependencies
 rand = "0.8.5"

--- a/modules/cli/Cargo.toml
+++ b/modules/cli/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 # Workspace dependencies
-louvain-application = "0.0.0"
-louvain-domain = "0.0.0"
+louvain-application = { path = "../application" }
+louvain-domain = { path = "../domain" }
 
 # External dependencies
 clap = { version = "4.0", features = ["derive"] }


### PR DESCRIPTION
Hey there, was looking for a rust implementation of the Louvain algorithm and found this very useful. However, since it is not published to crates-io I had to install it directly from the git repo and currently if you try and import it into your Cargo.toml like so:
```
louvain = { git = "https://github.com/Splines/fast-louvain.git", branch = "main" }
```

You'll get the following error:

```
error: no matching package named `louvain-cli` found
location searched: registry `crates-io`
required by package `louvain v0.0.0 (https://github.com/Splines/fast-louvain.git?branch=main#6b5cee07)`
    ... which satisfies git dependency `louvain` of package `megamatch_lambda v0.1.0 (/Users/andrewwalker/Development/kittools-tmp/kittools/crates/megamatch_lambda)`
```

Seems like it's an issue with package resolution that you won't see locally with the current setup. I made a couple of modifications to the Cargo.toml for the workspace and in the `application` and `cli` packages to fix this problem.

Forking with these changes fixed my problem but I figured I'd take a shot at pushing this upstream in case someone else has a similar issue. I understand that this project is still under construction/unfinished but this is a good workaround until a real release is published.

Awesome work by the way!
